### PR TITLE
Return null when an item cannot be found during a Group Join

### DIFF
--- a/src/core/enumerable.js
+++ b/src/core/enumerable.js
@@ -539,7 +539,7 @@
                         }
 
                         var c = e.getCurrent();
-                        var innerElement = lookup.has(outerKeySelector(c)) ? lookup.get(outerKeySelector(c)) : Enumerable.empty();
+                        var innerElement = lookup.has(outerKeySelector(c)) ? lookup.get(outerKeySelector(c)) : null;
                         current = resultSelector(c, innerElement);
                         return true;
                     },


### PR DESCRIPTION
Commit [40803c](https://github.com/Reactive-Extensions/IxJS/pull/14/commits/40803c92987e1beb2466a1ad5bb75376d4904fe0) fixed issue [#14](https://github.com/Reactive-Extensions/IxJS/pull/14) but when an item in the inner enumerable is not found, it returns an empty enumerable.  It should return null.
